### PR TITLE
Sparsely allocate 16GB scratch image by default

### DIFF
--- a/repo-debian.sh
+++ b/repo-debian.sh
@@ -243,7 +243,7 @@ deb_metadata() {
         [[ -f "$PackagesFix" ]] && PackagesOld="$PackagesFix"
 
         echo "[Merge] :: cat $PackagesOld $PackagesNew > Packages"
-        cat "$PackagesOld" "$PackagesNew" > Packages
+        cat "$PackagesOld" "$PackagesNew" > Packages || err "scratch image too small"
     else
         echo "[New] :: mv -v $PackagesNew Packages"
         mv -v "$PackagesNew" Packages

--- a/repo-rpm.sh
+++ b/repo-rpm.sh
@@ -189,7 +189,7 @@ rpm_metadata() {
     pkg_diff=$(comm -1 -3 <(echo "$pkg_cache" | sort) <(echo "$pkg_list" | sort))
     for pkg in $(echo -e "${pkg_diff}\n${pkg_modify}" | sort -u); do
         echo ":: ${subpath}/${pkg}"
-        echo "${subpath}/${pkg}" >> "$fileManifest"
+        echo "${subpath}/${pkg}" >> "$fileManifest" || err "scratch image too small"
     done
     echo
 


### PR DESCRIPTION
 - add `--no-sparse` flag to restore previous behavior
 - hard exit if run out of disk space detected
 - fixes root cause for #10 